### PR TITLE
修正图片地址识别正则

### DIFF
--- a/util/contentfmt.go
+++ b/util/contentfmt.go
@@ -17,7 +17,7 @@ const (
 
 var (
 	codeRegexp    = regexp.MustCompile("(?s:```(.+?)```)")
-	imgRegexp     = regexp.MustCompile(`(https?://[\w./:]+/[\w./]+\.(jpg|jpe|jpeg|gif|png))`)
+	imgRegexp     = regexp.MustCompile(`(https?://[-\w./:]+/[\w./]+\.(jpg|jpe|jpeg|gif|png))`)
 	gistRegexp    = regexp.MustCompile(`(https?://gist\.github\.com/([a-zA-Z0-9-]+/)?[\d]+)`)
 	mentionRegexp = regexp.MustCompile(`(?:\s|^)@([a-zA-Z0-9\p{Han}]{1,32})\s?`)
 	urlRegexp     = regexp.MustCompile(`([^;"='>])(https?://[^\s<]+[^\s<.)])`)


### PR DESCRIPTION
有些云服务器提供商的域名里包含【-】这个字符，加上了才能识别