### PR TITLE
为项目添加基于 Github Actions 的持续集成与交叉编译生成

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           go-version: '>=1.19.0'
       - name: Build
         run: |
-          go get github.com/valyala/fasthttp@v1.51.0
+          go mod tidy
           go build -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }} -v .
         env:
           GOOS: ${{ matrix.goos }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,7 @@ jobs:
           go-version: '>=1.19.0'
       - name: Build
         run: |
-          go mod download github.com/valyala/fasthttp
-          go mod download golang.org/x/crypto
+          go get github.com/valyala/fasthttp@v1.51.0
           go build -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }} -v .
         env:
           GOOS: ${{ matrix.goos }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }} 
       - name: Build
-        run: go build -v . -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}
+        run: go build -v main.go -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}
   
       - name: Handle for Windows Build
         if: ${{ env.GOOS == 'windows' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
   
       - name: Upload a Windows Build Artifact
         uses: actions/upload-artifact@v4
-        if: ${{ env.GOOS == 'windows' }}
+        if: ${{ matrix.goos == 'windows' }}
         with:
           name: goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}.exe
           path: goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,15 +29,12 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '>=1.19.0'
-      - name: Build binary
+      - name: Build
         run: |
-          go build .
+          go build -v main.go -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }} 
-      - name: Build
-        run: go build -v main.go -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}
-  
       - name: Handle for Windows Build
         if: ${{ env.GOOS == 'windows' }}
         run: mv goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }} goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
           go-version: '>=1.19.0'
       - name: Build
         run: |
-          go build -v main.go -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}
+          go build -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }} -v main.go
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }} 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '>=1.19.0'
-      - run: go -version
       - name: Build binary
         run: |
           go build .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,12 +37,12 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }} 
       - name: Handle for Windows Build
-        if: ${{ env.GOOS == 'windows' }}
+        if: ${{ matrix.goos == 'windows' }}
         run: mv goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }} goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}.exe
   
       - name: Upload a Non-Windows Build Artifact
         uses: actions/upload-artifact@v4
-        if: ${{ env.GOOS != 'windows' }}
+        if: ${{ matrix.goos != 'windows' }}
         with:
           name: goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}
           path: goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Auto Build
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  Compile:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goarch: amd64
+            goos: linux
+          - goarch: amd64
+            goos: darwin
+          - goarch: amd64
+            goos: windows 
+          - goarch: arm64
+            goos: linux
+          - goarch: arm64
+            goos: darwin
+          - goarch: arm64
+            goos: windows 
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Setting up Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: '>=1.19.0'
+      - run: go -version
+      - name: Build binary
+        run: |
+          go build .
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }} 
+      - name: Build
+        run: go build -v . -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}
+  
+      - name: Handle for Windows Build
+        if: ${{ env.GOOS == 'windows' }}
+        run: mv goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }} goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}.exe
+  
+      - name: Upload a Non-Windows Build Artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ env.GOOS != 'windows' }}
+        with:
+          name: goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}
+  
+      - name: Upload a Windows Build Artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ env.GOOS == 'windows' }}
+        with:
+          name: goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}.exe
+          path: goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }}.exe
+        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,9 @@ jobs:
           go-version: '>=1.19.0'
       - name: Build
         run: |
-          go build -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }} -v main.go
+          go mod download github.com/valyala/fasthttp
+          go mod download golang.org/x/crypto
+          go build -o goyoubbs-${{ matrix.goos }}-${{ matrix.goarch }} -v .
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }} 


### PR DESCRIPTION
抱歉， Commits 略微有点多……因为一只在调试构建……

现在在项目拥有者手动触发或推送更新时会自动进行交叉编译，目前通过配置会生成 `Windows`, `Linux`, `MacOS` 三个系统的`amd64`,`arm64`版本。

